### PR TITLE
Google AIP: Generate standard HTTP routes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -37,8 +37,8 @@
     "example:alpaca": "deno -A examples/alpaca/main.ts",
     "check": "deno check **/*.ts",
     "outdated": "deno outdated --update --latest",
-    "test": "deno test --allow-all",
-    "test:update": "deno task test -- --update",
+    "test": "deno test --allow-all --unstable-kv",
+    "test:update": "deno task test --unstable-kv -- --update",
     "publish:dry": "deno publish --dry-run --allow-dirty",
     "lint": "deno lint && deno doc --lint  **/*.ts"
   },

--- a/lib/declarative/common/google-aip/methods/custom-method/custom-method.ts
+++ b/lib/declarative/common/google-aip/methods/custom-method/custom-method.ts
@@ -2,7 +2,11 @@ import type { OpenAPIV3_1 } from "openapi-types";
 import type { Class, Declarative } from "#/lib/declarative/declarative.ts";
 import { createDecoratorFactory } from "#/lib/declarative/decorator.ts";
 import type { ValueJSONSchema } from "#/lib/declarative/common/json-schema/json-schema.ts";
-import type { ValuePathsObject } from "#/lib/declarative/common/openapi/openapi.ts";
+import type {
+  Handler,
+  ValueHttpRoutes,
+  ValuePathsObject,
+} from "#/lib/declarative/common/openapi/openapi.ts";
 import type { OperationOptions } from "#/lib/declarative/common/google-aip/operation.ts";
 import {
   toOperationPath,
@@ -21,6 +25,8 @@ export const customMethod: (
   },
 });
 
+// TODO: Represent batch methods in terms of custom methods.
+
 /**
  * declarativeCustomMethod returns the customMethod operation of the resource.
  *
@@ -36,13 +42,13 @@ export function declarativeCustomMethod<TValue extends ValueCustomMethods>(
 
     const resourceName = options?.resourceName ?? name;
     const pathname = toCustomMethodPath(resourceName, options);
+    const httpMethod: OpenAPIV3_1.HttpMethods =
+      (options?.httpMethod ?? "post") as OpenAPIV3_1.HttpMethods;
 
     value ??= {} as TValue;
     value["paths"] ??= {};
     value["paths"][pathname] ??= {};
-    value["paths"][pathname][
-      (options?.httpMethod as OpenAPIV3_1.HttpMethods) ?? "post"
-    ] = {
+    value["paths"][pathname][httpMethod] = {
       description: options?.description ?? `Custom ${options?.name}`,
       requestBody: {
         required: true,
@@ -71,6 +77,15 @@ export function declarativeCustomMethod<TValue extends ValueCustomMethods>(
         },
       },
     };
+
+    if (options?.handler !== undefined) {
+      value["routes"] ??= [];
+      value["routes"].push({
+        pattern: new URLPattern({ pathname }),
+        method: httpMethod,
+        handler: options.handler,
+      });
+    }
 
     return value;
   };
@@ -107,9 +122,15 @@ export interface CustomMethodOptions extends OperationOptions {
    * httpMethod is the HTTP method for the custom method. Defaults to "post".
    */
   httpMethod?: string;
+
+  /**
+   * handler is the handler for the custom method.
+   */
+  handler?: Handler;
 }
 
 /**
  * ValueCustomMethods is the value of the customMethod operation of the resource.
  */
-export interface ValueCustomMethods extends ValueJSONSchema, ValuePathsObject {}
+export interface ValueCustomMethods
+  extends ValueJSONSchema, ValuePathsObject, ValueHttpRoutes {}

--- a/lib/declarative/common/google-aip/methods/custom-method/custom-method.ts
+++ b/lib/declarative/common/google-aip/methods/custom-method/custom-method.ts
@@ -35,12 +35,12 @@ export function declarativeCustomMethod<TValue extends ValueCustomMethods>(
     }
 
     const resourceName = options?.resourceName ?? name;
-    const operationPath = toCustomMethodPath(resourceName, options);
+    const pathname = toCustomMethodPath(resourceName, options);
 
     value ??= {} as TValue;
     value["paths"] ??= {};
-    value["paths"][operationPath] ??= {};
-    value["paths"][operationPath][
+    value["paths"][pathname] ??= {};
+    value["paths"][pathname][
       (options?.httpMethod as OpenAPIV3_1.HttpMethods) ?? "post"
     ] = {
       description: options?.description ?? `Custom ${options?.name}`,

--- a/lib/declarative/common/google-aip/methods/custom-method/custom-method.ts
+++ b/lib/declarative/common/google-aip/methods/custom-method/custom-method.ts
@@ -31,7 +31,7 @@ export function declarativeCustomMethod<TValue extends ValueCustomMethods>(
 ): Declarative<TValue> {
   return (value, name): TValue => {
     if (options?.name === undefined) {
-      throw new Error("verb is required");
+      throw new Error("Custom method name is required");
     }
 
     const resourceName = options?.resourceName ?? name;
@@ -99,7 +99,7 @@ export function toCustomMethodPath(
  */
 export interface CustomMethodOptions extends OperationOptions {
   /**
-   * name is the prefix for the custom method. Must be a camelCase verb.
+   * name is the name of the custom method. Must be a camelCase verb.
    */
   name: string;
 

--- a/lib/declarative/common/google-aip/methods/standard-create/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-create/handler.test.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "@std/assert/equals";
+import { standardCreateHandler } from "./handler.ts";
+
+Deno.test("standardCreateHandler handles request", async () => {
+  const kv = await Deno.openKv(":memory:");
+  const handler = standardCreateHandler(kv, []);
+  const request = new Request("http://localhost", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "test" }),
+  });
+
+  const response = await handler(request);
+  assertEquals(response.status, 200);
+  assertEquals(await response.json(), { name: "test" });
+  kv.close();
+});

--- a/lib/declarative/common/google-aip/methods/standard-create/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-create/handler.test.ts
@@ -7,11 +7,11 @@ Deno.test("standardCreateHandler handles request", async () => {
   const request = new Request("http://localhost", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ name: "test" }),
+    body: JSON.stringify({ name: "fake" }),
   });
 
   const response = await handler(request);
   assertEquals(response.status, 200);
-  assertEquals(await response.json(), { name: "test" });
+  assertEquals(await response.json(), { name: "fake" });
   kv.close();
 });

--- a/lib/declarative/common/google-aip/methods/standard-create/handler.ts
+++ b/lib/declarative/common/google-aip/methods/standard-create/handler.ts
@@ -1,0 +1,27 @@
+/**
+ * standardCreateHandler is the handler for the standard Create operation of the
+ * resource.
+ */
+export function standardCreateHandler(
+  kv: Deno.Kv,
+  prefix: Deno.KvKey,
+): (request: Request) => Promise<Response> {
+  return async (request) => {
+    const body = await request.json();
+    const result = await kv.set([...prefix, body?.name], body);
+    if (!result?.ok) {
+      return new Response(JSON.stringify(result), {
+        status: 500,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+
+    return new Response(JSON.stringify(body), {
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  };
+}

--- a/lib/declarative/common/google-aip/methods/standard-create/mod.ts
+++ b/lib/declarative/common/google-aip/methods/standard-create/mod.ts
@@ -1,1 +1,2 @@
 export * from "./standard-create.ts";
+export * from "./handler.ts";

--- a/lib/declarative/common/google-aip/methods/standard-create/standard-create.ts
+++ b/lib/declarative/common/google-aip/methods/standard-create/standard-create.ts
@@ -32,7 +32,7 @@ export function declarativeStandardCreate<TValue extends ValueStandardCreate>(
 ): Declarative<TValue> {
   return (value, name) => {
     const resourceName = options?.resourceName ?? name;
-    const operationPath = toStandardCreatePath(
+    const pathname = toStandardCreatePath(
       resourceName,
       options?.collectionIdentifier,
       options?.parent,
@@ -40,8 +40,8 @@ export function declarativeStandardCreate<TValue extends ValueStandardCreate>(
 
     value ??= {} as TValue;
     value["paths"] ??= {};
-    value["paths"][operationPath] ??= {};
-    value["paths"][operationPath]["post"] = {
+    value["paths"][pathname] ??= {};
+    value["paths"][pathname]["post"] = {
       description: options?.description ?? `Creates ${resourceName}`,
       requestBody: {
         required: true,

--- a/lib/declarative/common/google-aip/methods/standard-create/standard-create.ts
+++ b/lib/declarative/common/google-aip/methods/standard-create/standard-create.ts
@@ -2,14 +2,15 @@ import type { Class, Declarative } from "#/lib/declarative/declarative.ts";
 import { createDecoratorFactory } from "#/lib/declarative/decorator.ts";
 import type { ValueJSONSchema } from "#/lib/declarative/common/json-schema/json-schema.ts";
 import type {
+  ValueHttpRoutes,
   ValuePathsObject,
-  ValueRoutes,
 } from "#/lib/declarative/common/openapi/openapi.ts";
 import type { OperationOptions } from "#/lib/declarative/common/google-aip/operation.ts";
 import {
   toOperationPath,
   toOperationSchema,
 } from "#/lib/declarative/common/google-aip/operation.ts";
+import { standardCreateHandler } from "./handler.ts";
 
 /**
  * standardCreate is the standard Create operation specification of the resource.
@@ -74,6 +75,20 @@ export function declarativeStandardCreate<TValue extends ValueStandardCreate>(
       },
     };
 
+    if (options?.kv !== undefined) {
+      const keyPrefix: Deno.KvKeyPart = toOperationPath(
+        resourceName,
+        options.collectionIdentifier,
+        options.parent,
+      );
+      value["routes"] ??= [];
+      value["routes"].push({
+        pattern: new URLPattern({ pathname }),
+        method: "POST",
+        handler: standardCreateHandler(options.kv, [keyPrefix]),
+      });
+    }
+
     return value;
   };
 }
@@ -94,10 +109,15 @@ export function toStandardCreatePath(
  * StandardCreateOptions is the options for the standard Create operation of the
  * resource.
  */
-export interface StandardCreateOptions extends OperationOptions {}
+export interface StandardCreateOptions extends OperationOptions {
+  /**
+   * kv is the Deno Kv instance to use in the HTTP handler.
+   */
+  kv?: Deno.Kv;
+}
 
 /**
  * ValueStandardCreate is the value of the standard Create operation of the resource.
  */
 export interface ValueStandardCreate
-  extends ValueJSONSchema, ValuePathsObject, ValueRoutes {}
+  extends ValueJSONSchema, ValuePathsObject, ValueHttpRoutes {}

--- a/lib/declarative/common/google-aip/methods/standard-create/standard-create.ts
+++ b/lib/declarative/common/google-aip/methods/standard-create/standard-create.ts
@@ -1,7 +1,10 @@
 import type { Class, Declarative } from "#/lib/declarative/declarative.ts";
 import { createDecoratorFactory } from "#/lib/declarative/decorator.ts";
 import type { ValueJSONSchema } from "#/lib/declarative/common/json-schema/json-schema.ts";
-import type { ValuePathsObject } from "#/lib/declarative/common/openapi/openapi.ts";
+import type {
+  ValuePathsObject,
+  ValueRoutes,
+} from "#/lib/declarative/common/openapi/openapi.ts";
 import type { OperationOptions } from "#/lib/declarative/common/google-aip/operation.ts";
 import {
   toOperationPath,
@@ -97,4 +100,4 @@ export interface StandardCreateOptions extends OperationOptions {}
  * ValueStandardCreate is the value of the standard Create operation of the resource.
  */
 export interface ValueStandardCreate
-  extends ValueJSONSchema, ValuePathsObject {}
+  extends ValueJSONSchema, ValuePathsObject, ValueRoutes {}

--- a/lib/declarative/common/google-aip/methods/standard-delete/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-delete/handler.test.ts
@@ -3,15 +3,15 @@ import { standardDeleteHandler } from "./handler.ts";
 
 Deno.test("standardDeleteHandler handles request", async () => {
   const kv = await Deno.openKv(":memory:");
-  await kv.set(["test"], { name: "test" });
+  await kv.set(["fake"], { name: "fake" });
 
   const handler = standardDeleteHandler(kv, []);
-  const request = new Request("http://localhost/test", { method: "DELETE" });
+  const request = new Request("http://localhost/fake", { method: "DELETE" });
   const response = await handler(
     request,
     new URLPattern({ pathname: "/:name" }).exec(request.url),
   );
   assertEquals(response.status, 200);
-  assertEquals((await kv.get(["test"]))?.value, null);
+  assertEquals((await kv.get(["fake"]))?.value, null);
   kv.close();
 });

--- a/lib/declarative/common/google-aip/methods/standard-delete/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-delete/handler.test.ts
@@ -6,10 +6,10 @@ Deno.test("standardDeleteHandler handles request", async () => {
   await kv.set(["test"], { name: "test" });
 
   const handler = standardDeleteHandler(kv, []);
-  const url = new URL("http://localhost/test");
+  const request = new Request("http://localhost/test", { method: "DELETE" });
   const response = await handler(
-    new Request(url),
-    new URLPattern({ pathname: "/:name" }).exec(url),
+    request,
+    new URLPattern({ pathname: "/:name" }).exec(request.url),
   );
   assertEquals(response.status, 200);
   assertEquals((await kv.get(["test"]))?.value, null);

--- a/lib/declarative/common/google-aip/methods/standard-delete/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-delete/handler.test.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "@std/assert/equals";
+import { standardDeleteHandler } from "./handler.ts";
+
+Deno.test("standardDeleteHandler handles request", async () => {
+  const kv = await Deno.openKv(":memory:");
+  await kv.set(["test"], { name: "test" });
+
+  const handler = standardDeleteHandler(kv, []);
+  const url = new URL("http://localhost/test");
+  const response = await handler(
+    new Request(url),
+    new URLPattern({ pathname: "/:name" }).exec(url),
+  );
+  assertEquals(response.status, 200);
+  assertEquals((await kv.get(["test"]))?.value, null);
+  kv.close();
+});

--- a/lib/declarative/common/google-aip/methods/standard-delete/handler.ts
+++ b/lib/declarative/common/google-aip/methods/standard-delete/handler.ts
@@ -1,0 +1,27 @@
+/**
+ * standardDeleteHandler is the handler for the standard Delete operation of the
+ * resource.
+ */
+export function standardDeleteHandler(
+  kv: Deno.Kv,
+  prefix: Deno.KvKey,
+): (request: Request, params?: URLPatternResult | null) => Promise<Response> {
+  return async (_request, params) => {
+    const name = params?.pathname.groups.name;
+    if (!name) {
+      return new Response("Name parameter is missing", {
+        status: 400,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+
+    await kv.delete([...prefix, name]);
+    return new Response("Resource deleted successfully", {
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  };
+}

--- a/lib/declarative/common/google-aip/methods/standard-delete/mod.ts
+++ b/lib/declarative/common/google-aip/methods/standard-delete/mod.ts
@@ -1,1 +1,2 @@
 export * from "./standard-delete.ts";
+export * from "./handler.ts";

--- a/lib/declarative/common/google-aip/methods/standard-delete/standard-delete.ts
+++ b/lib/declarative/common/google-aip/methods/standard-delete/standard-delete.ts
@@ -26,7 +26,7 @@ export function declarativeStandardDelete<TValue extends ValueStandardDelete>(
 ): Declarative<TValue> {
   return (value, name) => {
     const resourceName = options?.resourceName ?? name;
-    const operationPath = toStandardDeletePath(
+    const pathname = toStandardDeletePath(
       resourceName,
       options?.collectionIdentifier,
       options?.parent,
@@ -34,8 +34,8 @@ export function declarativeStandardDelete<TValue extends ValueStandardDelete>(
 
     value ??= {} as TValue;
     value["paths"] ??= {};
-    value["paths"][operationPath] ??= {};
-    value["paths"][operationPath]["delete"] = {
+    value["paths"][pathname] ??= {};
+    value["paths"][pathname]["delete"] = {
       description: options?.description ?? `Deletes ${resourceName}`,
       parameters: [{ name: "name", in: "path", required: true }],
       responses: {

--- a/lib/declarative/common/google-aip/methods/standard-get/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-get/handler.test.ts
@@ -3,15 +3,15 @@ import { standardGetHandler } from "./handler.ts";
 
 Deno.test("standardGetHandler handles request", async () => {
   const kv = await Deno.openKv(":memory:");
-  await kv.set(["test"], { name: "test" });
+  await kv.set(["fake"], { name: "fake" });
 
   const handler = standardGetHandler(kv, []);
-  const request = new Request("http://localhost/test");
+  const request = new Request("http://localhost/fake");
   const response = await handler(
     request,
     new URLPattern({ pathname: "/:name" }).exec(request.url),
   );
   assertEquals(response.status, 200);
-  assertEquals(await response.json(), { name: "test" });
+  assertEquals(await response.json(), { name: "fake" });
   kv.close();
 });

--- a/lib/declarative/common/google-aip/methods/standard-get/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-get/handler.test.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "@std/assert/equals";
+import { standardGetHandler } from "./handler.ts";
+
+Deno.test("standardGetHandler handles request", async () => {
+  const kv = await Deno.openKv(":memory:");
+  await kv.set(["test"], { name: "test" });
+
+  const handler = standardGetHandler(kv, []);
+  const url = new URL("http://localhost/test");
+  const response = await handler(
+    new Request(url),
+    new URLPattern({ pathname: "/:name" }).exec(url),
+  );
+  assertEquals(response.status, 200);
+  assertEquals(await response.json(), { name: "test" });
+  kv.close();
+});

--- a/lib/declarative/common/google-aip/methods/standard-get/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-get/handler.test.ts
@@ -6,10 +6,10 @@ Deno.test("standardGetHandler handles request", async () => {
   await kv.set(["test"], { name: "test" });
 
   const handler = standardGetHandler(kv, []);
-  const url = new URL("http://localhost/test");
+  const request = new Request("http://localhost/test");
   const response = await handler(
-    new Request(url),
-    new URLPattern({ pathname: "/:name" }).exec(url),
+    request,
+    new URLPattern({ pathname: "/:name" }).exec(request.url),
   );
   assertEquals(response.status, 200);
   assertEquals(await response.json(), { name: "test" });

--- a/lib/declarative/common/google-aip/methods/standard-get/handler.ts
+++ b/lib/declarative/common/google-aip/methods/standard-get/handler.ts
@@ -1,0 +1,36 @@
+/**
+ * standardGetHandler is the handler for the standard Get operation of the
+ * resource.
+ */
+export function standardGetHandler(
+  kv: Deno.Kv,
+  prefix: Deno.KvKey,
+): (request: Request, params?: URLPatternResult | null) => Promise<Response> {
+  return async (_request, params) => {
+    const name = params?.pathname.groups.name;
+    if (!name) {
+      return new Response("Name parameter is missing", {
+        status: 400,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+
+    const result = await kv.get([...prefix, name]);
+    if (result.value === null) {
+      return new Response(JSON.stringify(result), {
+        status: 404,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+
+    return new Response(JSON.stringify(result.value), {
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  };
+}

--- a/lib/declarative/common/google-aip/methods/standard-get/mod.ts
+++ b/lib/declarative/common/google-aip/methods/standard-get/mod.ts
@@ -1,1 +1,2 @@
 export * from "./standard-get.ts";
+export * from "./handler.ts";

--- a/lib/declarative/common/google-aip/methods/standard-get/standard-get.ts
+++ b/lib/declarative/common/google-aip/methods/standard-get/standard-get.ts
@@ -30,14 +30,14 @@ export function declarativeStandardGet<TValue extends ValueStandardGet>(
 ): Declarative<TValue> {
   return (value, name) => {
     const resourceName = options?.resourceName ?? name;
-    const operationPath = toStandardGetPath(
+    const pathname = toStandardGetPath(
       resourceName,
       options?.collectionIdentifier,
       options?.parent,
     );
     value ??= {} as TValue;
     value!.paths ??= {} as OpenAPIV3_1.PathsObject;
-    value!.paths[operationPath] ??= {
+    value!.paths[pathname] ??= {
       get: {
         description: options?.description ?? `Gets ${resourceName}`,
         parameters: [

--- a/lib/declarative/common/google-aip/methods/standard-list/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-list/handler.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from "@std/assert/equals";
+import { standardListHandler } from "./handler.ts";
+
+Deno.test("standardListHandler handles request", async () => {
+  const kv = await Deno.openKv(":memory:");
+  await kv.set(["test"], { name: "test" });
+
+  const handler = standardListHandler(kv, []);
+  const request = new Request("http://localhost", {
+    method: "GET",
+    headers: { "content-type": "application/json" },
+  });
+
+  const response = await handler(request);
+  assertEquals(response.status, 200);
+  assertEquals(await response.json(), [{ name: "test" }]);
+  kv.close();
+});

--- a/lib/declarative/common/google-aip/methods/standard-list/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-list/handler.test.ts
@@ -3,7 +3,7 @@ import { standardListHandler } from "./handler.ts";
 
 Deno.test("standardListHandler handles request", async () => {
   const kv = await Deno.openKv(":memory:");
-  await kv.set(["test"], { name: "test" });
+  await kv.set(["fake"], { name: "fake" });
 
   const handler = standardListHandler(kv, []);
   const request = new Request("http://localhost", {
@@ -13,6 +13,6 @@ Deno.test("standardListHandler handles request", async () => {
 
   const response = await handler(request);
   assertEquals(response.status, 200);
-  assertEquals(await response.json(), [{ name: "test" }]);
+  assertEquals(await response.json(), [{ name: "fake" }]);
   kv.close();
 });

--- a/lib/declarative/common/google-aip/methods/standard-list/handler.ts
+++ b/lib/declarative/common/google-aip/methods/standard-list/handler.ts
@@ -1,0 +1,24 @@
+/**
+ * standardListHandler is the handler for the standard List operation of the
+ * resource.
+ */
+export function standardListHandler(
+  kv: Deno.Kv,
+  prefix: Deno.KvKey,
+): (request: Request) => Promise<Response> {
+  return async (_request) => {
+    const result = await Array.fromAsync(kv.list({ prefix }));
+    return new Response(
+      JSON.stringify(
+        result.map((entry) => {
+          return entry.value;
+        }),
+      ),
+      {
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  };
+}

--- a/lib/declarative/common/google-aip/methods/standard-list/mod.ts
+++ b/lib/declarative/common/google-aip/methods/standard-list/mod.ts
@@ -1,1 +1,2 @@
 export * from "./standard-list.ts";
+export * from "./handler.ts";

--- a/lib/declarative/common/google-aip/methods/standard-list/standard-list.ts
+++ b/lib/declarative/common/google-aip/methods/standard-list/standard-list.ts
@@ -35,7 +35,7 @@ export function declarativeStandardList<TValue extends ValueStandardList>(
 
     const resourceName = options?.resourceName ?? name;
     const pluralizedResourceName = pluralize(resourceName);
-    const operationPath = toStandardListPath(
+    const pathname = toStandardListPath(
       resourceName,
       options?.collectionIdentifier,
       options?.parent,
@@ -43,8 +43,8 @@ export function declarativeStandardList<TValue extends ValueStandardList>(
 
     value ??= {} as TValue;
     value["paths"] ??= {};
-    value["paths"][operationPath] ??= {};
-    value["paths"][operationPath]["get"] = {
+    value["paths"][pathname] ??= {};
+    value["paths"][pathname]["get"] = {
       description: options?.description ?? `Lists ${pluralizedResourceName}`,
       parameters: [
         { name: "page_size", in: "query" },

--- a/lib/declarative/common/google-aip/methods/standard-update/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-update/handler.test.ts
@@ -1,0 +1,20 @@
+import { assertEquals } from "@std/assert/equals";
+import { standardUpdateHandler } from "./handler.ts";
+
+Deno.test("standardUpdateHandler handles request", async () => {
+  const kv = await Deno.openKv(":memory:");
+  const handler = standardUpdateHandler(kv, []);
+  const request = new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "test" }),
+  });
+
+  const response = await handler(
+    request,
+    new URLPattern({ pathname: "/:name" }).exec(request.url),
+  );
+  assertEquals(response.status, 200);
+  assertEquals(await response.json(), { name: "test" });
+  kv.close();
+});

--- a/lib/declarative/common/google-aip/methods/standard-update/handler.test.ts
+++ b/lib/declarative/common/google-aip/methods/standard-update/handler.test.ts
@@ -4,10 +4,10 @@ import { standardUpdateHandler } from "./handler.ts";
 Deno.test("standardUpdateHandler handles request", async () => {
   const kv = await Deno.openKv(":memory:");
   const handler = standardUpdateHandler(kv, []);
-  const request = new Request("http://localhost/test", {
+  const request = new Request("http://localhost/fake", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ name: "test" }),
+    body: JSON.stringify({ name: "fake" }),
   });
 
   const response = await handler(
@@ -15,6 +15,6 @@ Deno.test("standardUpdateHandler handles request", async () => {
     new URLPattern({ pathname: "/:name" }).exec(request.url),
   );
   assertEquals(response.status, 200);
-  assertEquals(await response.json(), { name: "test" });
+  assertEquals(await response.json(), { name: "fake" });
   kv.close();
 });

--- a/lib/declarative/common/google-aip/methods/standard-update/handler.ts
+++ b/lib/declarative/common/google-aip/methods/standard-update/handler.ts
@@ -1,0 +1,37 @@
+/**
+ * standardUpdateHandler is the handler for the standard Update operation of the
+ * resource.
+ */
+export function standardUpdateHandler(
+  kv: Deno.Kv,
+  prefix: Deno.KvKey,
+): (request: Request, params?: URLPatternResult | null) => Promise<Response> {
+  return async (request, params) => {
+    const name = params?.pathname.groups.name;
+    if (!name) {
+      return new Response("Name parameter is missing", {
+        status: 400,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+
+    const body = await request.json();
+    const result = await kv.set([...prefix, name], body);
+    if (!result?.ok) {
+      return new Response(JSON.stringify(result), {
+        status: 500,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }
+
+    return new Response(JSON.stringify(body), {
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  };
+}

--- a/lib/declarative/common/google-aip/methods/standard-update/mod.ts
+++ b/lib/declarative/common/google-aip/methods/standard-update/mod.ts
@@ -1,1 +1,2 @@
 export * from "./standard-update.ts";
+export * from "./handler.ts";

--- a/lib/declarative/common/google-aip/methods/standard-update/standard-update.ts
+++ b/lib/declarative/common/google-aip/methods/standard-update/standard-update.ts
@@ -29,7 +29,7 @@ export function declarativeStandardUpdate<TValue extends ValueStandardUpdate>(
 ): Declarative<TValue> {
   return (value, name) => {
     const resourceName = options?.resourceName ?? name;
-    const operationPath = toStandardUpdatePath(
+    const pathname = toStandardUpdatePath(
       resourceName,
       options?.collectionIdentifier,
       options?.parent,
@@ -37,8 +37,8 @@ export function declarativeStandardUpdate<TValue extends ValueStandardUpdate>(
 
     value ??= {} as TValue;
     value["paths"] ??= {};
-    value["paths"][operationPath] ??= {};
-    value["paths"][operationPath]["post"] = {
+    value["paths"][pathname] ??= {};
+    value["paths"][pathname]["post"] = {
       description: options?.description ?? `Updates ${resourceName}`,
       requestBody: {
         required: true,

--- a/lib/declarative/common/json-schema/json-schema.ts
+++ b/lib/declarative/common/json-schema/json-schema.ts
@@ -104,14 +104,14 @@ export function applyJSONSchemaMask(
 export type JSONSchemaMask = any | ((value: any) => any);
 
 /**
- * compile compiles the tsMorph properties into a JSON schema string.
+ * compile compiles the tsMorph properties into a JSON Schema string.
  */
 export function compile({ tsMorph }: ValueTsMorph): any {
   return TypeBoxFromSyntax({}, serialize({ tsMorph }));
 }
 
 /**
- * serialize serializes the tsMorph properties into a JSON schema string.
+ * serialize serializes the tsMorph properties into a JSON Schema string.
  */
 export function serialize({ tsMorph }: ValueTsMorph): string {
   if (tsMorph === undefined || tsMorph?.properties.length === 0) {

--- a/lib/declarative/common/openapi/openapi.ts
+++ b/lib/declarative/common/openapi/openapi.ts
@@ -22,7 +22,7 @@ export function specificationOf<TClass extends Class>(
 export function routesOf<TClass extends Class>(
   target: TClass,
 ): Route[] | undefined {
-  return getPrototypeValue<ValueOpenAPI>(target)?.routes;
+  return getPrototypeValue<ValueRoutes>(target)?.routes;
 }
 
 /**
@@ -133,16 +133,11 @@ export function declarativeOpenAPI<TValue extends ValueOpenAPI>(
 /**
  * ValueOpenAPI is the value associated with an OpenAPI specification.
  */
-export interface ValueOpenAPI {
+export interface ValueOpenAPI extends ValueRoutes {
   /**
    * specification is the top-level object of the OpenAPI specification.
    */
   specification?: OpenAPIV3_1.Document;
-
-  /**
-   * routes are the HTTP routes of the OpenAPI specification.
-   */
-  routes?: Route[];
 }
 
 /**
@@ -154,4 +149,14 @@ export interface ValuePathsObject {
    * paths is the paths object of the OpenAPI specification.
    */
   paths?: OpenAPIV3_1.PathsObject;
+}
+
+/**
+ * ValueRoutes is the value of the routes of the OpenAPI specification.
+ */
+export interface ValueRoutes {
+  /**
+   * routes are the HTTP routes of the OpenAPI specification.
+   */
+  routes?: Route[];
 }

--- a/lib/declarative/common/openapi/openapi.ts
+++ b/lib/declarative/common/openapi/openapi.ts
@@ -126,6 +126,19 @@ export function declarativeOpenAPI<TValue extends ValueOpenAPI>(
           },
         },
       },
+      routes: [
+        ...(options?.routes ?? []),
+        ...(options?.resources
+          ?.map((resource) => {
+            const routes = routesOf(resource);
+            if (routes === undefined) {
+              return [];
+            }
+
+            return routes;
+          })
+          .flat() ?? []),
+      ],
     } as TValue;
   };
 }

--- a/lib/declarative/common/openapi/openapi.ts
+++ b/lib/declarative/common/openapi/openapi.ts
@@ -22,7 +22,7 @@ export function specificationOf<TClass extends Class>(
 export function routesOf<TClass extends Class>(
   target: TClass,
 ): Route[] | undefined {
-  return getPrototypeValue<ValueRoutes>(target)?.routes;
+  return getPrototypeValue<ValueHttpRoutes>(target)?.routes;
 }
 
 /**
@@ -133,7 +133,7 @@ export function declarativeOpenAPI<TValue extends ValueOpenAPI>(
 /**
  * ValueOpenAPI is the value associated with an OpenAPI specification.
  */
-export interface ValueOpenAPI extends ValueRoutes {
+export interface ValueOpenAPI extends ValueHttpRoutes {
   /**
    * specification is the top-level object of the OpenAPI specification.
    */
@@ -152,9 +152,9 @@ export interface ValuePathsObject {
 }
 
 /**
- * ValueRoutes is the value of the routes of the OpenAPI specification.
+ * ValueHttpRoutes is the value of the routes of the OpenAPI specification.
  */
-export interface ValueRoutes {
+export interface ValueHttpRoutes {
   /**
    * routes are the HTTP routes of the OpenAPI specification.
    */

--- a/lib/declarative/common/openapi/openapi.ts
+++ b/lib/declarative/common/openapi/openapi.ts
@@ -1,11 +1,11 @@
-import type { Route } from "@std/http/unstable-route";
+import type { Handler, Route } from "@std/http/unstable-route";
 import type { OpenAPIV3_1 } from "openapi-types";
 import type { Class, Declarative } from "#/lib/declarative/declarative.ts";
 import { getPrototypeValue } from "#/lib/declarative/declarative.ts";
 import { createDecoratorFactory } from "#/lib/declarative/decorator.ts";
 import { jsonSchemaOf } from "#/lib/declarative/common/json-schema/json-schema.ts";
 
-export type { Route };
+export type { Handler, Route };
 
 /**
  * specificationOf returns the OpenAPI specification of the class.

--- a/lib/declarative/common/ts-morph/ts-morph.ts
+++ b/lib/declarative/common/ts-morph/ts-morph.ts
@@ -41,7 +41,7 @@ export interface TsMorphProperty {
 }
 
 /**
- * tsMorphOf returns the ts-morph of the class.
+ * tsMorphOf returns the ts-morph analysis of the class.
  */
 export function tsMorphOf<TClass extends Class>(
   target: TClass,
@@ -60,7 +60,7 @@ export interface ValueTsMorph {
 }
 
 /**
- * tsMorph is a decorator for ts-morph.
+ * tsMorph is a decorator to analyze the class with ts-morph.
  */
 export function tsMorphDecoratorFactory(
   project: Project,


### PR DESCRIPTION
Each standard Google AIP method can have its HTTP server route logic automatically derived when paired with persistent data storage for resources. This pull request implements the HTTP handlers for each standard method to enable this automatic route inference.